### PR TITLE
Add simple CPU usage monitor

### DIFF
--- a/cpu_monitor.py
+++ b/cpu_monitor.py
@@ -1,0 +1,24 @@
+#!/usr/bin/env python3
+"""Simple curses-based per-core CPU usage monitor."""
+
+import curses
+import psutil
+import time
+
+
+def draw(stdscr):
+    curses.curs_set(0)
+    while True:
+        stdscr.erase()
+        cpu_percents = psutil.cpu_percent(percpu=True)
+        stdscr.addstr(0, 0, "CPU core load:")
+        for i, percent in enumerate(cpu_percents):
+            bar_len = int(percent / 4)  # 25 char width bar
+            bar = "#" * bar_len
+            stdscr.addstr(i + 1, 0, f"Core {i}: {percent:5.1f}% {bar}")
+        stdscr.refresh()
+        time.sleep(1)
+
+
+if __name__ == "__main__":
+    curses.wrapper(draw)


### PR DESCRIPTION
## Summary
- add `cpu_monitor.py` script to display per-core CPU usage in a curses-based interface

## Testing
- `python -m py_compile cpu_monitor.py`
- `python - <<'PY'
import cpu_monitor
print('module loaded')
PY`


------
https://chatgpt.com/codex/tasks/task_e_68975e1b559c8327811cedf4b7ad8942